### PR TITLE
fix json peg definition

### DIFF
--- a/oldsample/mongo.nez
+++ b/oldsample/mongo.nez
@@ -1,3 +1,5 @@
+export
+	= JSONObject
 File
 	= S* (JSONObject / Array) S*
 Chunk
@@ -15,6 +17,13 @@ Value
 	/ Null
 	/ True
 	/ False
+	/ ObjectId
+
+ObjectId 
+        = 'ObjectId' '("' { [0-9a-z]+ #ObjectId } '")'
+
+ID
+        = [0-9a-z]+
 
 Array
 	= { '[' (S* @Value (VALUESEP @Value)* )? S* ']' #List }
@@ -23,7 +32,7 @@ String
 	= '"' { ('\\"' / '\\\\' / !'"' .)* #String } '"'
 
 Number
-        = { '-'? INT #Integer (&[.eE] FRAC? EXP? #Float)? }
+        = { '-'? INT (FRAC EXP? #Float / '' #Integer) }
 True
         = { 'true'  #True }
 False


### PR DESCRIPTION
Current version of json peg does not accept following json.

```
$ java -jar nez.jar ast -p oldsample/json.nez -t '{"A" : 1e10}'
((string):1) [error] syntax error
 {"A" : 1e10}
         ^
```

This PR fix definition of json's peg to accept it.
