### PR TITLE
javac task needs encoding="UTF-8" option

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -24,7 +24,7 @@
 	<!-- ================================== -->
 	<target name="build">
 		<mkdir dir="${build_dir}" />
-		<javac fork="true" srcdir="${source_dir}" destdir="${build_dir}" target="1.8" source="1.8"
+		<javac fork="true" encoding="UTF-8" srcdir="${source_dir}" destdir="${build_dir}" target="1.7" source="1.7"
 			debug="yes" debuglevel="lines,vars,source" includeantruntime="false">
 			<classpath path="${jline_jar}" />
 			<classpath path="${asm_jar}" />


### PR DESCRIPTION
This PR fix following compile error. We need to add encoding option to 
compile the code that includes multi-byte charcters in Linux.

```
build:
    [mkdir] Created dir: /home/masa/src/nez-1/build
    [javac] Compiling 171 source files to /home/masa/src/nez-1/build
    [javac] /home/masa/src/nez-1/src/nez/lib/NezGrammar.java:15: error: unmappable character for encoding ASCII
    [javac]       return Choice(c(9, 10), t("'\\r'"), t(" "), Sequence(t("???")));
    [javac]                                                               ^
    [javac] /home/masa/src/nez-1/src/nez/lib/NezGrammar.java:15: error: unmappable character for encoding ASCII
    [javac]       return Choice(c(9, 10), t("'\\r'"), t(" "), Sequence(t("???")));
    [javac]                                                                ^
    [javac] /home/masa/src/nez-1/src/nez/lib/NezGrammar.java:15: error: unmappable character for encoding ASCII
    [javac]       return Choice(c(9, 10), t("'\\r'"), t(" "), Sequence(t("???")));
    [javac]                                                                 ^
    [javac] 3 errors
```
