### PR TITLE
added backslash checking at AbstractParserGenerator._byte(int)

### DIFF
--- a/tool/nez/tool/parser/AbstractParserGenerator.java
+++ b/tool/nez/tool/parser/AbstractParserGenerator.java
@@ -289,6 +289,9 @@ public abstract class AbstractParserGenerator implements SourceGenerator {
 	}
 
 	protected String _byte(int ch) {
+		if (ch == 92) { // [ad-hoc] insert one more backslash '\\'
+			return "'" + "\\\\" + "'";
+		}
 		if (ch < 128 && (!Character.isISOControl(ch))) {
 			return "'" + (char) ch + "'";
 		}


### PR DESCRIPTION
- added checking backslash in order to print the escape sequence '\\'
- since this is an ad-hoc modification, please review the code before merging
